### PR TITLE
Added bot for scraping course IDs from Vorlesungsverzeichnis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@
 
 * python installed
 
+For scraping IDs from VVZ (only on linux, but can be adapted in the VVZ_bot.py file for other configurations):
+* chrome installed 
+* chrome webdriver for the same version of chrome installed (in /usr/bin/) (https://sites.google.com/a/chromium.org/chromedriver/downloads)
+
 ## How to use
 
 * clone or download files
 * open console in installation folder
+* run ``` python VVZ_bot.py ``` to scrape the module IDs of the economics faculty from Vorlesungsverzeichnis
 * run ``` python rating_grade_correlation.py ``` to scrape data for hypothesis 1
 * run ``` python average_rating_and_grade_per_semester.py ``` to scrape data for hypothesis 2
 
 ## What it does
 
+* VVZ_bot.py script creates module IDs list for the following scripts
 * script reads all module ids from the input file (by default 'module_list.txt')
 * fetches data of all modules
 * writes output file (by default 'output.CSV') with all selected field

--- a/VVZ_bot.py
+++ b/VVZ_bot.py
@@ -72,5 +72,5 @@ for i in range(totMods):
 
 
 # Save the list to a file
-with open("id_list.txt", "w") as file:
+with open("module_list.txt", "w") as file:
     file.writelines(idList)


### PR DESCRIPTION
Bot for scraping course IDs from the UZH's Vorlesungsverzeichnis (https://studentservices.uzh.ch/uzh/vvz/). The code was included in the Social Computing final report, but for completeness I'm adding it now in the project's repository.